### PR TITLE
Fix `Flask.jsonify` Problem with `Decimal` Values

### DIFF
--- a/coral/sql_query_mapper.py
+++ b/coral/sql_query_mapper.py
@@ -1,3 +1,4 @@
+import decimal
 import logging
 import os
 import sys
@@ -257,7 +258,15 @@ class QueryElements:
 
             # transform row into a dictionary
             for row in rows:
-                result.append(dict(row))
+                # create dictionary of row
+                row_dict = dict(row)
+                # iterate over all key:value pairs
+                for key in row_dict:
+                    if isinstance(row_dict[key], decimal.Decimal):
+                        # cast decimal to float
+                        row_dict[key] = float(row_dict[key])
+
+                result.append(row_dict)
 
         except exc.SQLAlchemyError as e:
             _log.error("SQLAlchemy Error: %s", e)


### PR DESCRIPTION
fixes Caleydo/cohort#685 

# Summary
With the switch to FastAPI we also switch to `Flask.jsonify()`, which per default returns a `string` for `decimal` data types.
For the visualization we need numbers (not strings), which lead to problems for the default behaviour of `jsonify()`

## Code Change
- added **type check**, and **cast** to `float` if value is `decimal`

## Implmentation
**before:**
![image](https://user-images.githubusercontent.com/42137747/168114361-2e09379d-5ee2-4871-b5ba-43f2724cd8b0.png)


**now:**
![image](https://user-images.githubusercontent.com/42137747/168114086-d718cbf7-1674-438d-8c3a-d02671570387.png)
