### PR TITLE
Automatically select root cohort if onboarding was already done

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -431,6 +431,13 @@ export class CohortApp {
           // get Old elements
           if (dataset.chtOverviewElements !== null) {
             await this._cohortOverview.generateOverviewProv(dataset.chtOverviewElements);
+          } else {
+            // there are no old elements, just the initial cohort.
+            // check if user is currently onboarding - otherwise directly click the cohort
+            const tooltip = OnboardingManager.tooltips.get('rootCohort');
+            if (!tooltip?.props?.showOnCreate) {
+              CohortSelectionListener.get().handleSelectionEvent(new CohortSelectionEvent(rootCohort, true));
+            }
           }
         }
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import {select, Selection} from 'd3v7';
+import { select, Selection } from 'd3v7';
 import SplitGrid from 'split-grid';
 import {
   AppContext,


### PR DESCRIPTION
Closes https://github.com/Caleydo/cohort/issues/579

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- If onboarding tooltip will be shown - i.e. no cookie - than the user has to click the root cohort
- If onboarding tolltip is not shown - only on hover - than the root cohort is automatically selected

### Screenshots

![579](https://user-images.githubusercontent.com/10337788/194283565-3d963cda-c906-4311-b0a0-5082abdcd8da.gif)

### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
