### PR TITLE
fix: gene scores columns by spreading subtype object

### DIFF
--- a/src/Taskview/SearchBar.ts
+++ b/src/Taskview/SearchBar.ts
@@ -1083,7 +1083,6 @@ export class SearchBar {
   public getSelectedOptions(): IOption[] {
     const badges = select(this._container).selectAll('.selected-option-badge');
     const badgesData = badges.data();
-    console.log('badgesData: ', badgesData);
     return badgesData as IOption[];
   }
 

--- a/src/Taskview/SearchBar.ts
+++ b/src/Taskview/SearchBar.ts
@@ -934,7 +934,7 @@ export class SearchBar {
           .html((v: IDataSubtypeConfig) => v.name)
           .on('click', (event, v: IDataSubtypeConfig) => {
             // merge subtype with the with d as the d.name is only available in the d variable
-            const dataSubType = { ...d, v };
+            const dataSubType = { ...d, ...v };
             const badgeName = this._composeGeneDataTypeName(data.optionText, dataSubType.name);
             const badgeData = deepCopy(data);
             badgeData.optionData = { subType: dataSubType, type: (dataSubType as any).dataTypeId };
@@ -1083,6 +1083,7 @@ export class SearchBar {
   public getSelectedOptions(): IOption[] {
     const badges = select(this._container).selectAll('.selected-option-badge');
     const badgesData = badges.data();
+    console.log('badgesData: ', badgesData);
     return badgesData as IOption[];
   }
 


### PR DESCRIPTION
Closes  https://github.com/Caleydo/cohort/issues/708
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- This was something left from the eslint refactoring, just a minor merging problem

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
