### PR TITLE
fix: add attribute hover style is not applied

### DIFF
--- a/src/Taskview/SearchBar.ts
+++ b/src/Taskview/SearchBar.ts
@@ -300,10 +300,11 @@ export class SearchBar {
         if (d.optionType === 'gene') {
           // set global optionId
           this._geneHoverOptionId = d.optionId;
+          const currentTarget = event.currentTarget as HTMLElement; // store current target as it becomes null by the time the timeout is executed
           setTimeout(() => {
             // update detail after timeout time global and current optionId is equal
             if (d.optionId === this._geneHoverOptionId) {
-              this._mouseOverHandler(d, event.currentTarget);
+              this._mouseOverHandler(d, currentTarget);
             }
           }, 200);
         } else {


### PR DESCRIPTION
Closes https://github.com/Caleydo/cohort/issues/718

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The error was a result of the `event.currentTarget` being null by the time the `setTimeout` is executed
- This fixes also the hover background on the gene when the gene datatype is hovered

### Screenshots
#### before

![gr-before](https://github.com/Caleydo/coral/assets/51322092/543e1faf-ec2c-4fa6-abd3-db6c9db5caf6)

#### after

![gr-after](https://github.com/Caleydo/coral/assets/51322092/a911b2ce-aa26-49fc-867d-fa62277fb702)




### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
